### PR TITLE
Fixes #46 ; Introduce and hook in GameSuccessEvaluator

### DIFF
--- a/minesweeper-engine/src/main/java/com/jayasuryat/minesweeperengine/controller/impl/GameController.kt
+++ b/minesweeper-engine/src/main/java/com/jayasuryat/minesweeperengine/controller/impl/GameController.kt
@@ -69,13 +69,18 @@ public class GameController(
 
         public fun getDefault(): GameController {
             val gridRevealer = GridRevealer()
+            val successEvaluator = GameSuccessEvaluator()
             return GameController(
                 cellReveler = CellRevealer(
                     gridRevealer = gridRevealer,
                     radiallySorter = RadiallySorter(),
+                    successEvaluator = successEvaluator,
                 ),
                 cellFlagger = CellFlagger(),
-                valueCellReveler = ValueCellRevealer(gridRevealer = gridRevealer),
+                valueCellReveler = ValueCellRevealer(
+                    gridRevealer = gridRevealer,
+                    successEvaluator = successEvaluator,
+                ),
             )
         }
     }

--- a/minesweeper-engine/src/main/java/com/jayasuryat/minesweeperengine/controller/impl/handler/CellFlagger.kt
+++ b/minesweeper-engine/src/main/java/com/jayasuryat/minesweeperengine/controller/impl/handler/CellFlagger.kt
@@ -18,10 +18,8 @@ package com.jayasuryat.minesweeperengine.controller.impl.handler
 import com.jayasuryat.minesweeperengine.controller.ActionHandler
 import com.jayasuryat.minesweeperengine.controller.model.MinefieldAction
 import com.jayasuryat.minesweeperengine.controller.model.MinefieldEvent
-import com.jayasuryat.minesweeperengine.model.cell.MineCell
 import com.jayasuryat.minesweeperengine.model.cell.RawCell
 import com.jayasuryat.minesweeperengine.model.grid.Grid
-import com.jayasuryat.minesweeperengine.util.mutate
 import com.jayasuryat.util.exhaustive
 
 internal class CellFlagger : ActionHandler<MinefieldAction.OnCellLongPressed> {
@@ -38,37 +36,6 @@ internal class CellFlagger : ActionHandler<MinefieldAction.OnCellLongPressed> {
             is RawCell.UnrevealedCell.UnFlaggedCell -> action.cell.asFlagged()
         }.exhaustive
 
-        val isGameComplete = isGameComplete(
-            grid = grid,
-            updatedCell = updatedCell,
-        )
-
-        return if (isGameComplete) MinefieldEvent.OnGameComplete(updatedCells = listOf(updatedCell))
-        else MinefieldEvent.OnCellsUpdated(updatedCells = listOf(updatedCell))
-    }
-
-    private fun isGameComplete(
-        grid: Grid,
-        updatedCell: RawCell,
-    ): Boolean {
-
-        val modGrid = grid.mutate { this[updatedCell.position] = updatedCell }
-
-        val totalMineCount = grid.totalMines
-
-        var totalFlaggedCount = 0
-        var correctFlaggedCount = 0
-
-        modGrid.cells.flatten().forEach { cell ->
-
-            if (cell is RawCell.UnrevealedCell.FlaggedCell) {
-
-                totalFlaggedCount++
-                if (totalFlaggedCount > totalMineCount) return false
-                if (cell.asRevealed().cell is MineCell.Mine) correctFlaggedCount++
-            }
-        }
-
-        return correctFlaggedCount == totalMineCount
+        return MinefieldEvent.OnCellsUpdated(updatedCells = listOf(updatedCell))
     }
 }

--- a/minesweeper-engine/src/main/java/com/jayasuryat/minesweeperengine/controller/impl/handler/CellRevealer.kt
+++ b/minesweeper-engine/src/main/java/com/jayasuryat/minesweeperengine/controller/impl/handler/CellRevealer.kt
@@ -28,6 +28,7 @@ import com.jayasuryat.util.exhaustive
 internal class CellRevealer(
     private val gridRevealer: GridRevealer,
     private val radiallySorter: RadiallySorter,
+    private val successEvaluator: GameSuccessEvaluator,
 ) : ActionHandler<MinefieldAction.OnCellClicked> {
 
     override suspend fun onAction(
@@ -47,7 +48,7 @@ internal class CellRevealer(
                 )
 
                 if (isGameComplete) MinefieldEvent.OnGameComplete(updatedCells = listOf(revealed))
-                else MinefieldEvent.OnCellsUpdated(updatedCells = listOf(revealed),)
+                else MinefieldEvent.OnCellsUpdated(updatedCells = listOf(revealed))
             }
 
             is MineCell.ValuedCell.EmptyCell -> {
@@ -71,14 +72,7 @@ internal class CellRevealer(
         grid: Grid,
         updatedCell: RawCell,
     ): Boolean {
-
         val modGrid = grid.mutate { this[updatedCell.position] = updatedCell }
-
-        val totalCount = grid.gridSize.rows * grid.gridSize.columns
-        val nonMineCellsCount = totalCount - grid.totalMines
-
-        val revealedCellsCount = modGrid.cells.flatten().count { it is RawCell.RevealedCell }
-
-        return revealedCellsCount == nonMineCellsCount
+        return successEvaluator.isGameComplete(modGrid)
     }
 }

--- a/minesweeper-engine/src/main/java/com/jayasuryat/minesweeperengine/controller/impl/handler/GameSuccessEvaluator.kt
+++ b/minesweeper-engine/src/main/java/com/jayasuryat/minesweeperengine/controller/impl/handler/GameSuccessEvaluator.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 Jaya Surya Thotapalli
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.jayasuryat.minesweeperengine.controller.impl.handler
 
 import android.util.Log

--- a/minesweeper-engine/src/main/java/com/jayasuryat/minesweeperengine/controller/impl/handler/GameSuccessEvaluator.kt
+++ b/minesweeper-engine/src/main/java/com/jayasuryat/minesweeperengine/controller/impl/handler/GameSuccessEvaluator.kt
@@ -1,0 +1,20 @@
+package com.jayasuryat.minesweeperengine.controller.impl.handler
+
+import android.util.Log
+import com.jayasuryat.minesweeperengine.model.cell.RawCell
+import com.jayasuryat.minesweeperengine.model.grid.Grid
+
+internal class GameSuccessEvaluator {
+
+    fun isGameComplete(
+        grid: Grid,
+    ): Boolean {
+
+        val totalCount = grid.gridSize.rows * grid.gridSize.columns
+        val nonMineCellsCount = totalCount - grid.totalMines
+
+        val revealedCellsCount = grid.cells.flatten().count { it is RawCell.RevealedCell }
+        Log.d("Im alive", "Im alive, (revealedCellsCount) $revealedCellsCount == $nonMineCellsCount (nonMineCellsCount)")
+        return revealedCellsCount == nonMineCellsCount
+    }
+}


### PR DESCRIPTION
This PR fixes #46.

Changes :
- Use `GameSuccessEvaluator` to drive game success evaluation logic from a single place
- Remove (obsolete) evaluation from `CellFlagger`
- Evaluate on every `cell` click and `value cell` reveal