### PR TITLE
Implement persistence layer

### DIFF
--- a/buildSrc/src/main/java/Dependency.kt
+++ b/buildSrc/src/main/java/Dependency.kt
@@ -19,6 +19,8 @@ object Dependency {
 
         const val gameScreen = ":ui-game"
         const val difficultySelection = ":ui-difficulty-selection"
+
+        const val data = ":data"
     }
 
     object Compose {
@@ -55,4 +57,7 @@ object Dependency {
     private const val taktVersion = "2.1.1"
     const val takt = "jp.wasabeef:takt:$taktVersion"
     const val taktNoOp = "jp.wasabeef:takt-no-op:$taktVersion"
+
+    const val settings = "com.russhwolf:multiplatform-settings-no-arg:0.8.1"
+    const val kotlinxSerialization = "org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.2"
 }

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -1,0 +1,83 @@
+import org.jetbrains.kotlin.gradle.dsl.KotlinCompile
+
+plugins {
+    kotlin("multiplatform")
+    kotlin("native.cocoapods")
+    id("com.android.library")
+}
+
+version = "1.0"
+
+kotlin {
+
+    android()
+    iosX64()
+    iosArm64()
+    //iosSimulatorArm64() sure all ios dependencies support this target
+
+    cocoapods {
+        summary = "Some description for the Shared Module"
+        homepage = "Link to the Shared Module homepage"
+        ios.deploymentTarget = "14.1"
+        framework {
+            baseName = "data"
+        }
+    }
+
+    sourceSets {
+
+        val commonMain by getting {
+            dependencies {
+                implementation(Dependency.settings)
+                implementation(Dependency.kotlinxSerialization)
+            }
+        }
+        val commonTest by getting {
+            dependencies {
+                implementation(kotlin("test-common"))
+                implementation(kotlin("test-annotations-common"))
+            }
+        }
+
+        val androidMain by getting
+        val androidTest by getting {
+            dependencies {
+                implementation(kotlin("test-junit"))
+                implementation("junit:junit:4.13.2")
+            }
+        }
+
+        val iosX64Main by getting
+        val iosX64Test by getting
+
+        val iosArm64Main by getting
+        val iosArm64Test by getting
+
+        val iosMain by creating {
+            dependsOn(commonMain)
+            iosX64Main.dependsOn(this)
+            iosArm64Main.dependsOn(this)
+            //iosSimulatorArm64Main.dependsOn(this)
+        }
+        val iosTest by creating {
+            dependsOn(commonTest)
+            iosX64Test.dependsOn(this)
+            iosArm64Test.dependsOn(this)
+            //iosSimulatorArm64Test.dependsOn(this)
+        }
+
+        //val iosSimulatorArm64Main by getting
+        //val iosSimulatorArm64Test by getting
+    }
+
+    explicitApi()
+}
+
+android {
+    compileSdk = BuildConfig.compileSdk
+    sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
+    defaultConfig {
+        minSdk = BuildConfig.minSdk
+        targetSdk = BuildConfig.targetSdk
+    }
+}

--- a/data/data.podspec
+++ b/data/data.podspec
@@ -1,0 +1,45 @@
+Pod::Spec.new do |spec|
+    spec.name                     = 'data'
+    spec.version                  = '1.0'
+    spec.homepage                 = 'Link to the Shared Module homepage'
+    spec.source                   = { :git => "Not Published", :tag => "Cocoapods/#{spec.name}/#{spec.version}" }
+    spec.authors                  = ''
+    spec.license                  = ''
+    spec.summary                  = 'Some description for the Shared Module'
+
+    spec.vendored_frameworks      = "build/cocoapods/framework/data.framework"
+    spec.libraries                = "c++"
+    spec.module_name              = "#{spec.name}_umbrella"
+
+    spec.ios.deployment_target = '14.1'
+
+                
+
+    spec.pod_target_xcconfig = {
+        'KOTLIN_PROJECT_PATH' => ':data',
+        'PRODUCT_MODULE_NAME' => 'data',
+    }
+
+    spec.script_phases = [
+        {
+            :name => 'Build data',
+            :execution_position => :before_compile,
+            :shell_path => '/bin/sh',
+            :script => <<-SCRIPT
+                if [ "YES" = "$COCOAPODS_SKIP_KOTLIN_BUILD" ]; then
+                  echo "Skipping Gradle build task invocation due to COCOAPODS_SKIP_KOTLIN_BUILD environment variable set to \"YES\""
+                  exit 0
+                fi
+                set -ev
+                REPO_ROOT="$PODS_TARGET_SRCROOT"
+                "$REPO_ROOT/../gradlew" -p "$REPO_ROOT" $KOTLIN_PROJECT_PATH:syncFramework \
+                    -Pkotlin.native.cocoapods.platform=$PLATFORM_NAME \
+                    -Pkotlin.native.cocoapods.archs="$ARCHS" \
+                    -Pkotlin.native.cocoapods.configuration=$CONFIGURATION \
+                    -Pkotlin.native.cocoapods.cflags="$OTHER_CFLAGS" \
+                    -Pkotlin.native.cocoapods.paths.headers="$HEADER_SEARCH_PATHS" \
+                    -Pkotlin.native.cocoapods.paths.frameworks="$FRAMEWORK_SEARCH_PATHS"
+            SCRIPT
+        }
+    ]
+end

--- a/data/src/androidMain/AndroidManifest.xml
+++ b/data/src/androidMain/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest package="com.jayasuryat.data" />

--- a/data/src/commonMain/kotlin/com/jayasuryat/data/settings/sources/definitions/UserPreferences.kt
+++ b/data/src/commonMain/kotlin/com/jayasuryat/data/settings/sources/definitions/UserPreferences.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 Jaya Surya Thotapalli
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.jayasuryat.data.settings.sources.definitions
 
 public interface UserPreferences {

--- a/data/src/commonMain/kotlin/com/jayasuryat/data/settings/sources/definitions/UserPreferences.kt
+++ b/data/src/commonMain/kotlin/com/jayasuryat/data/settings/sources/definitions/UserPreferences.kt
@@ -1,0 +1,10 @@
+package com.jayasuryat.data.settings.sources.definitions
+
+public interface UserPreferences {
+
+    public suspend fun getIsSoundEnabled(): Boolean
+    public suspend fun setIsSoundEnabled(enabled: Boolean)
+
+    public suspend fun getIsVibrationEnabled(): Boolean
+    public suspend fun setIsVibrationEnabled(enabled: Boolean)
+}

--- a/data/src/commonMain/kotlin/com/jayasuryat/data/settings/sources/impl/UserPreferencesImpl.kt
+++ b/data/src/commonMain/kotlin/com/jayasuryat/data/settings/sources/impl/UserPreferencesImpl.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 Jaya Surya Thotapalli
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.jayasuryat.data.settings.sources.impl
 
 import com.jayasuryat.data.settings.sources.definitions.UserPreferences

--- a/data/src/commonMain/kotlin/com/jayasuryat/data/settings/sources/impl/UserPreferencesImpl.kt
+++ b/data/src/commonMain/kotlin/com/jayasuryat/data/settings/sources/impl/UserPreferencesImpl.kt
@@ -1,0 +1,23 @@
+package com.jayasuryat.data.settings.sources.impl
+
+import com.jayasuryat.data.settings.sources.definitions.UserPreferences
+import com.jayasuryat.data.store.DataStore
+
+public class UserPreferencesImpl(
+    private val store: DataStore,
+) : UserPreferences {
+
+    override suspend fun getIsSoundEnabled(): Boolean = store.getBoolean(PREF_SOUND_ENABLED)
+    override suspend fun setIsSoundEnabled(enabled: Boolean): Unit =
+        store.putBoolean(PREF_SOUND_ENABLED, enabled)
+
+    override suspend fun getIsVibrationEnabled(): Boolean = store.getBoolean(PREF_VIBRATION_ENABLED)
+    override suspend fun setIsVibrationEnabled(enabled: Boolean): Unit =
+        store.putBoolean(PREF_VIBRATION_ENABLED, enabled)
+
+    private companion object {
+
+        private const val PREF_SOUND_ENABLED: String = "pref:sound"
+        private const val PREF_VIBRATION_ENABLED: String = "pref:vibration"
+    }
+}

--- a/data/src/commonMain/kotlin/com/jayasuryat/data/store/DataStore.kt
+++ b/data/src/commonMain/kotlin/com/jayasuryat/data/store/DataStore.kt
@@ -1,0 +1,50 @@
+package com.jayasuryat.data.store
+
+import com.russhwolf.settings.Settings
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+@Suppress("RedundantSuspendModifier", "unused")
+public class DataStore constructor(
+    private val settings: Settings,
+    @PublishedApi internal val json: Json,
+) {
+
+    public suspend fun putString(key: String, value: String): Unit = settings.putString(key, value)
+    public suspend fun getString(key: String): String? = settings.getString(key)
+        .takeIf { it.isNotBlank() }
+
+    public suspend fun putInt(key: String, value: Int): Unit = settings.putInt(key, value)
+    public suspend fun getInt(key: String, default: Int = 0): Int = settings.getInt(key, default)
+
+    public suspend fun putLong(key: String, value: Long): Unit = settings.putLong(key, value)
+    public suspend fun getLong(key: String, defValue: Long = -1): Long? {
+        val value = settings.getLong(key, -1)
+        return if (value == defValue) null else value
+    }
+
+    public suspend fun putBoolean(key: String, value: Boolean): Unit =
+        settings.putBoolean(key, value)
+
+    public suspend fun getBoolean(key: String): Boolean = settings.getBoolean(key, false)
+
+    public suspend inline fun <reified T> putObject(key: String, value: T): Unit =
+        putString(key, json.encodeToString(value))
+
+    public suspend inline fun <reified T> getObject(key: String): T? {
+        val data = getString(key)
+        if (data.isNullOrEmpty()) return null
+        return json.decodeFromString(data)
+    }
+
+    public suspend fun remove(vararg keys: String) {
+        keys.forEach {
+            settings.remove(it)
+        }
+    }
+
+    public suspend fun clear() {
+        settings.clear()
+    }
+}

--- a/data/src/commonMain/kotlin/com/jayasuryat/data/store/DataStore.kt
+++ b/data/src/commonMain/kotlin/com/jayasuryat/data/store/DataStore.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 Jaya Surya Thotapalli
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.jayasuryat.data.store
 
 import com.russhwolf.settings.Settings

--- a/data/src/commonMain/kotlin/com/jayasuryat/data/store/DataStore.kt
+++ b/data/src/commonMain/kotlin/com/jayasuryat/data/store/DataStore.kt
@@ -23,7 +23,11 @@ import kotlinx.serialization.json.Json
 @Suppress("RedundantSuspendModifier", "unused")
 public class DataStore constructor(
     private val settings: Settings,
-    @PublishedApi internal val json: Json,
+    @PublishedApi internal val json: Json = Json {
+        encodeDefaults = true
+        ignoreUnknownKeys = true
+        isLenient = true
+    },
 ) {
 
     public suspend fun putString(key: String, value: String): Unit = settings.putString(key, value)


### PR DESCRIPTION
- Added ability to persist simple user preferences. 
- Added a new `data` module to host all of this logic
- Chose [russhwolf's multiplatform-settings](https://github.com/russhwolf/multiplatform-settings) library for persisting user preferences.

Closes (#54)