### PR TITLE
Persist `game data` on every `state change`

### DIFF
--- a/ui-game/src/main/java/com/jayasuryat/uigame/GameViewModel.kt
+++ b/ui-game/src/main/java/com/jayasuryat/uigame/GameViewModel.kt
@@ -77,7 +77,7 @@ class GameViewModel(
                 coroutineScope = defaultScope,
                 musicManager = soundManager,
                 vibrationManager = vibrationManager,
-                onGameInitiated = { saveCurrentGameState() },
+                onStateChanged = { saveCurrentGameState() },
             )
 
             val screenStatus = GameScreenStatus.Loaded(

--- a/ui-game/src/main/java/com/jayasuryat/uigame/logic/ActionListener.kt
+++ b/ui-game/src/main/java/com/jayasuryat/uigame/logic/ActionListener.kt
@@ -50,7 +50,7 @@ internal class ActionListener(
     private val coroutineScope: CoroutineScope,
     private val musicManager: MusicManager,
     private val vibrationManager: VibrationManager,
-    private val onGameInitiated: () -> Unit,
+    private val onStateChanged: (newState: GameState) -> Unit,
 ) : CellInteractionListener {
 
     internal val statefulGrid: StatefulGrid = initialGrid.grid.asStatefulGrid()
@@ -176,8 +176,7 @@ internal class ActionListener(
         val previousState = _gameState.value
         val newState = resolveGameState(event = event) ?: return
         _gameState.value = newState
-
-        if (previousState == GameState.Idle && newState is GameState.GameStarted) onGameInitiated()
+        if (previousState != newState) onStateChanged(newState)
     }
 
     private fun updateGameProgress(statefulGrid: StatefulGrid) {


### PR DESCRIPTION
###### Alright!, as fate would have it!, one last more commit to go, hopefully!

Instead of saving game state on `game initialisation`, saving the game sate on every `state change` now.
This would give the overall game much appropriate behaviour. Rather than having the need to properly listen and rely on `lifecycles` and hoping for the data to get persisted in time, this way, all the necessary data points would be saved as soon as they get triggered.

Adds on to the issue #70 and the PR #84